### PR TITLE
Updated CmakeLists.txt to address cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,7 @@ else()
                         HEADER_NAME
                           torch/script.h
                           torch.h
-                        LIBRARY_NAME torch
-                        SEARCH_PATHS "")
+                        LIBRARY_NAME torch)
 endif()
 
 if(${Torch_FOUND})
@@ -90,8 +89,7 @@ else()
                           onnxruntime_run_options_config_keys.h
                           onnxruntime_session_options_config_keys.h
                           provider_options.h
-                        LIBRARY_NAME onnxruntime
-                        SEARCH_PATHS "")
+                        LIBRARY_NAME onnxruntime)
 endif()
 
 if(${OnnxRuntime_FOUND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,27 @@
 if(NOT ${ENABLE_SQLITE})
   message(STATUS "ORAN requires sqlite3 library")
   return()
+else()
+  set(sqlite_libraries
+      ${SQLite3_LIBRARIES}
+  )
 endif()
 
-find_external_library(DEPENDENCY_NAME Torch
-                      HEADER_NAME
-                        torch/script.h
-                        torch.h
-                      LIBRARY_NAME torch
-                      SEARCH_PATHS $ENV{LIBTORCHPATH})
+if(DEFINED ENV{LIBTORCHPATH})
+  find_external_library(DEPENDENCY_NAME Torch
+                        HEADER_NAME
+                          torch/script.h
+                          torch.h
+                        LIBRARY_NAME torch
+                        SEARCH_PATHS $ENV{LIBTORCHPATH})
+else()
+  find_external_library(DEPENDENCY_NAME Torch
+                        HEADER_NAME
+                          torch/script.h
+                          torch.h
+                        LIBRARY_NAME torch
+                        SEARCH_PATHS "")
+endif()
 
 if(${Torch_FOUND})
   include_directories(${Torch_INCLUDE_DIRS})
@@ -57,16 +70,29 @@ if(${Torch_FOUND})
   )
 endif()
 
-find_external_library(DEPENDENCY_NAME OnnxRuntime
-                      HEADER_NAME
-                        cpu_provider_factory.h
-                        onnxruntime_c_api.h
-                        onnxruntime_cxx_api.h
-                        onnxruntime_run_options_config_keys.h
-                        onnxruntime_session_options_config_keys.h
-                        provider_options.h
-                      LIBRARY_NAME onnxruntime
-                      SEARCH_PATHS $ENV{LIBONNXPATH})
+if(DEFINED ENV{LIBONNXPATH})
+  find_external_library(DEPENDENCY_NAME OnnxRuntime
+                        HEADER_NAME
+                          cpu_provider_factory.h
+                          onnxruntime_c_api.h
+                          onnxruntime_cxx_api.h
+                          onnxruntime_run_options_config_keys.h
+                          onnxruntime_session_options_config_keys.h
+                          provider_options.h
+                        LIBRARY_NAME onnxruntime
+                        SEARCH_PATHS $ENV{LIBONNXPATH})
+else()
+  find_external_library(DEPENDENCY_NAME OnnxRuntime
+                        HEADER_NAME
+                          cpu_provider_factory.h
+                          onnxruntime_c_api.h
+                          onnxruntime_cxx_api.h
+                          onnxruntime_run_options_config_keys.h
+                          onnxruntime_session_options_config_keys.h
+                          provider_options.h
+                        LIBRARY_NAME onnxruntime
+                        SEARCH_PATHS "")
+endif()
 
 if(${OnnxRuntime_FOUND})
   include_directories(${OnnxRuntime_INCLUDE_DIRS})
@@ -165,9 +191,9 @@ build_lib(
     ${libcore}
     ${libnetwork}
     ${liblte}
-    ${libsqlite3}
-    ${onnx_libraries}
+    ${sqlite_libraries}
     ${torch_libraries}
+    ${onnxruntime_libraries}
   TEST_SOURCES
     test/oran-test-suite.cc
 )


### PR DESCRIPTION
Several warnings are issued by cmake, especially when the torch and/or onnx libraries are not found on the system, due to various cmake variables being left undefined. These changes should resolve those warnings.