### PR TITLE
Fix: GetRsrq() in OranReportLteUeRsrpRsrq returns incorrect value

### DIFF
--- a/model/oran-report-lte-ue-rsrp-rsrq.cc
+++ b/model/oran-report-lte-ue-rsrp-rsrq.cc
@@ -141,7 +141,7 @@ OranReportLteUeRsrpRsrq::GetRsrq() const
 {
     NS_LOG_FUNCTION(this);
 
-    return m_rsrp;
+    return m_rsrq;
 }
 
 bool


### PR DESCRIPTION
Fixes a bug where `OranReportLteUeRsrpRsrq::GetRsrq()` was incorrectly returning the RSRP value (`m_rsrp`) instead of the RSRQ value (`m_rsrq`).

This has been corrected to return `m_rsrq`.