### PR TITLE
Fix LTE eNB registration in data repository example

### DIFF
--- a/examples/oran-data-repository-example.cc
+++ b/examples/oran-data-repository-example.cc
@@ -61,8 +61,8 @@ main(int argc, char* argv[])
     // Register three nodes
     // Register wired node
     uint64_t wiredE2NodeId = repository->RegisterNode(OranNearRtRic::NodeType::WIRED, 1);
-    // Registere LTE eNB with
-    repository->RegisterNodeLteUe(2, 1);
+    // Register LTE eNB
+    repository->RegisterNodeLteEnb(2, 1);
     // Register LTE UE
     uint64_t lteUeE2NodeId = repository->RegisterNodeLteUe(3, 1);
 


### PR DESCRIPTION
## Summary

Fixes `oran-data-repository-example.cc` so the LTE eNB example node is registered with `RegisterNodeLteEnb()` instead of `RegisterNodeLteUe()`.

The old code inserted the eNB node into the LTE UE table and reused IMSI 1 with the later UE registration.